### PR TITLE
Fixes load order, adds meta support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,17 +9,17 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "1.1.0-1.10"
+version = "1.2.0-1.12.2"
 group= "com.ewyboy.seeddrop"
 archivesBaseName = "SeedDrop"
 
 minecraft {
-    version = "1.10.2-12.18.0.2010"
+    version = "1.12.2-14.23.0.2550"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.
@@ -27,7 +27,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20160518"
+    mappings = "snapshot_20171003"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 14 12:28:28 PDT 2015
+#Mon Nov 27 19:18:02 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.7-all.zip

--- a/src/main/java/com/ewyboy/seeddrop/SeedDrop.java
+++ b/src/main/java/com/ewyboy/seeddrop/SeedDrop.java
@@ -4,6 +4,7 @@ import com.ewyboy.seeddrop.loaders.ConfigLoader;
 import com.ewyboy.seeddrop.loaders.SeedLoader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 import java.io.File;
@@ -18,8 +19,12 @@ public class SeedDrop {
     public static final String MOD_NAME = "SeedDrop";
 
     @EventHandler
-    public void init(FMLPreInitializationEvent event) {
+    public void preInit(FMLPreInitializationEvent event) {
         ConfigLoader.init(new File("config/" , MOD_NAME + ".cfg"));
+    }
+
+    @EventHandler
+    public void init(FMLInitializationEvent event) {
         SeedLoader.registerSeeds();
     }
 }

--- a/src/main/java/com/ewyboy/seeddrop/SeedDrop.java
+++ b/src/main/java/com/ewyboy/seeddrop/SeedDrop.java
@@ -6,6 +6,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 
@@ -18,8 +19,11 @@ public class SeedDrop {
     public static final String MOD_ID = "seeddrop";
     public static final String MOD_NAME = "SeedDrop";
 
+    public static Logger LOGGER;
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
+        LOGGER = event.getModLog();
         ConfigLoader.init(new File("config/" , MOD_NAME + ".cfg"));
     }
 

--- a/src/main/java/com/ewyboy/seeddrop/loaders/ConfigLoader.java
+++ b/src/main/java/com/ewyboy/seeddrop/loaders/ConfigLoader.java
@@ -28,7 +28,7 @@ public class ConfigLoader {
         Configuration config = new Configuration(configurationFile);
         customDrops = config.getStringList("SeedDrop Drop List", Configuration.CATEGORY_GENERAL, customDrops,
                 "How to configure this mod:" + "\n" +
-                "\n" + "First Line: minecraft:dirt  [What to drop when grass is broken]" +
+                "\n" + "First Line: minecraft:dirt:<meta>  [What to drop when grass is broken, meta is optional]" +
                 "\n" + "Second Line: 20  [Drop weight for item/block above (Vanilla Wheat Seeds is 10)]" +
                 "\n" + "You can edit / remove all the entries on this list as well as add new ones." + "\n" + "\n"
         );

--- a/src/main/java/com/ewyboy/seeddrop/loaders/SeedLoader.java
+++ b/src/main/java/com/ewyboy/seeddrop/loaders/SeedLoader.java
@@ -1,14 +1,66 @@
 package com.ewyboy.seeddrop.loaders;
 
+import com.ewyboy.seeddrop.SeedDrop;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 
-/** Created by EwyBoy **/
+/**
+ * Created by EwyBoy
+ **/
 public class SeedLoader {
     public static void registerSeeds() {
+
+        // Short-circuit if the number of entries is not even.
+        if ((ConfigLoader.customDrops.length & 1) != 0) {
+            SeedDrop.LOGGER.error("Mismatched number of entries, should be paired. Please see config file for format.");
+            return;
+        }
+
         for (int i = 0; i < ConfigLoader.customDrops.length; i += 2) {
-            MinecraftForge.addGrassSeed(new ItemStack(Item.getByNameOrId(ConfigLoader.customDrops[i])), Integer.parseInt(ConfigLoader.customDrops[i+1]));
+
+            String configStringItem = ConfigLoader.customDrops[i];
+            String[] splitStringItem = configStringItem.split(":");
+
+            // Check that the split string array has either two or three elements.
+            if (splitStringItem.length < 2
+                    || splitStringItem.length > 3) {
+                SeedDrop.LOGGER.error("Invalid item string syntax: '" + configStringItem
+                        + "', should be '<domain>:<id>', or '<domain>:<id>:<meta>'");
+                continue;
+            }
+
+            int meta = 0;
+
+            if (splitStringItem.length == 3) {
+                // A meta value was supplied, try to parse it and log an error if we can't.
+
+                try {
+                    meta = Integer.parseInt(splitStringItem[2]);
+
+                } catch (NumberFormatException e) {
+                    SeedDrop.LOGGER.error("Invalid item meta value: " + splitStringItem[2]);
+                    continue;
+                }
+            }
+
+            Item item = Item.getByNameOrId(splitStringItem[0] + ":" + splitStringItem[1]);
+
+            // Log an error if the item was not found.
+            if (item == null) {
+                SeedDrop.LOGGER.error("Unable to locate item: " + splitStringItem[0] + ":" + splitStringItem[1]);
+                continue;
+            }
+
+            String configStringWeight = ConfigLoader.customDrops[i + 1];
+
+            try {
+                int weight = Integer.parseInt(configStringWeight);
+                MinecraftForge.addGrassSeed(new ItemStack(item, 1, meta), weight);
+
+            } catch (NumberFormatException e) {
+                SeedDrop.LOGGER.error("Invalid weight value: " + configStringWeight);
+            }
         }
     }
 }


### PR DESCRIPTION
# Load Order
Items initialized by mods that had a preInit phase after this mod weren't being recognized by this mod when it tried to add the drops. I moved the call to registerSeeds() to the init phase. This ensures that all mods have a chance to initialize their items / blocks in the preInit phase before this mod tries to add them as seed drops.

# Meta Support
I needed meta support for items such as survivalist:rock:1. The registerSeeds() method now parses for meta and supplies some error logging if the user makes a typo while configuring.

# Notes
I made these changes mainly for myself and my private modpack, but you are more than welcome to merge them in. :)